### PR TITLE
Removed "protected" keyword for Glue 2.0

### DIFF
--- a/shared/src/main/scala/shared/BaseGlueScript.scala
+++ b/shared/src/main/scala/shared/BaseGlueScript.scala
@@ -10,7 +10,7 @@ abstract class BaseGlueScript {
   implicit val sparkSession: SparkSession = Spark.sparkSession
   implicit val glueCtx: GlueContext = Spark.glueCtx
 
-  protected def main(sysArgs: Array[String]): Unit = {
+  def main(sysArgs: Array[String]): Unit = {
     val args: Map[String, String] = GlueUtils.parseArgs(sysArgs)
 
     Job.init(args("JOB_NAME"), glueCtx, args.asJava)


### PR DESCRIPTION
Glue 1.0 used the YARN resource manager, whereas Glue 2.0 uses an AWS
proprietary resource manager. This changed the way Scala classes are
loaded. A side effect of this is that methods marked private/protected
will not be visible to the AWS resource manager as they belong to a
different package.